### PR TITLE
feat: add peppol credit note support

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -90,7 +90,7 @@ def get_einvoice(invoice: str | SalesInvoice) -> bytes:
 		xml_bytes = peppol_generator.get_xml_bytes()
 		peppol_validator = PEPPOLValidator()
 		xml_bytes = peppol_validator.validate_xml_structure(xml_bytes)
-		schema = get_xsd_schema(profile)
+		schema = get_xsd_schema(profile, invoice)
 		if schema:
 			return peppol_validator.validate_xml_against_xsd(xml_bytes, schema)
 		return xml_bytes

--- a/eu_einvoice/peppol/generator.py
+++ b/eu_einvoice/peppol/generator.py
@@ -104,8 +104,10 @@ class PEPPOLGenerator:
         
         issue_date = ET.SubElement(self.root, f"{{{self.namespaces['cbc']}}}IssueDate")
         issue_date.text = self.format_date(self.invoice.posting_date)
-        
-        if self.invoice.due_date:
+
+        # DueDate is only allowed in Invoice, not in CreditNote
+        is_credit_note = hasattr(self.invoice, 'is_return') and self.invoice.is_return
+        if self.invoice.due_date and not is_credit_note:
             due_date = ET.SubElement(self.root, f"{{{self.namespaces['cbc']}}}DueDate")
             due_date.text = self.format_date(self.invoice.due_date)
 

--- a/eu_einvoice/peppol/generator.py
+++ b/eu_einvoice/peppol/generator.py
@@ -108,8 +108,10 @@ class PEPPOLGenerator:
         if self.invoice.due_date:
             due_date = ET.SubElement(self.root, f"{{{self.namespaces['cbc']}}}DueDate")
             due_date.text = self.format_date(self.invoice.due_date)
-        
-        invoice_type = ET.SubElement(self.root, f"{{{self.namespaces['cbc']}}}InvoiceTypeCode")
+
+        # Use CreditNoteTypeCode for credit notes, InvoiceTypeCode for invoices
+        type_code_element = 'CreditNoteTypeCode' if is_credit_note else 'InvoiceTypeCode'
+        invoice_type = ET.SubElement(self.root, f"{{{self.namespaces['cbc']}}}{type_code_element}")
         invoice_type.text = self.get_invoice_type_code(self.invoice)
         
         currency_code = ET.SubElement(self.root, f"{{{self.namespaces['cbc']}}}DocumentCurrencyCode")
@@ -247,12 +249,17 @@ class PEPPOLGenerator:
     
     def _add_line_item(self, root: ET.Element, item):
         # Add a single line item
-        invoice_line = ET.SubElement(self.root, f"{{{self.namespaces['cac']}}}InvoiceLine")
-        
+        # Use CreditNoteLine for credit notes, InvoiceLine for regular invoices
+        is_credit_note = hasattr(self.invoice, 'is_return') and self.invoice.is_return
+        line_element_name = 'CreditNoteLine' if is_credit_note else 'InvoiceLine'
+        quantity_element_name = 'CreditedQuantity' if is_credit_note else 'InvoicedQuantity'
+
+        invoice_line = ET.SubElement(self.root, f"{{{self.namespaces['cac']}}}{line_element_name}")
+
         line_id = ET.SubElement(invoice_line, f"{{{self.namespaces['cbc']}}}ID")
         line_id.text = str(item.idx)
-        
-        quantity = ET.SubElement(invoice_line, f"{{{self.namespaces['cbc']}}}InvoicedQuantity")
+
+        quantity = ET.SubElement(invoice_line, f"{{{self.namespaces['cbc']}}}{quantity_element_name}")
         quantity.text = str(flt(item.qty, item.precision("qty")))
         quantity.set("unitCode", self.map_unit_code(item.uom))
         
@@ -481,11 +488,15 @@ class PEPPOLGenerator:
     
     def initialize_peppol_xml(self) -> ET.Element:
         # Initialize the PEPPOL XML document with root element and namespaces
-        root = ET.Element('{urn:oasis:names:specification:ubl:schema:xsd:Invoice-2}Invoice')
-        
+        # Use CreditNote root element for credit notes (is_return=1), Invoice otherwise
+        if hasattr(self.invoice, 'is_return') and self.invoice.is_return:
+            root = ET.Element('{urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2}CreditNote')
+        else:
+            root = ET.Element('{urn:oasis:names:specification:ubl:schema:xsd:Invoice-2}Invoice')
+
         for prefix, uri in self.namespaces.items():
             ET.register_namespace(prefix, uri)
-            
+
         return root
     
     def finalize_xml_document(self, root: ET.Element) -> str:

--- a/eu_einvoice/utils.py
+++ b/eu_einvoice/utils.py
@@ -51,9 +51,20 @@ PROFILE_TO_XSD_SCHEMA = {
 }
 
 
-def get_xsd_schema(profile: EInvoiceProfile) -> str:
-	"""Return the XSD schema name for PEPPOL profile."""
-	return PROFILE_TO_XSD_SCHEMA.get(profile)
+def get_xsd_schema(profile: EInvoiceProfile, invoice=None) -> str:
+	"""Return the XSD schema name for PEPPOL profile.
+
+	For PEPPOL, returns UBL-CreditNote-2.1 for credit notes (is_return=1),
+	or UBL-Invoice-2.1 for regular invoices.
+	"""
+	schema = PROFILE_TO_XSD_SCHEMA.get(profile)
+
+	# For PEPPOL, use CreditNote schema if it's a return invoice
+	if profile == EInvoiceProfile.PEPPOL and invoice:
+		if hasattr(invoice, 'is_return') and invoice.is_return:
+			schema = "UBL-CreditNote-2.1"
+
+	return schema
 
 
 def get_drafthorse_schema(profile: EInvoiceProfile) -> str:


### PR DESCRIPTION
## Add PEPPOL Credit Note support

### Problem
Credit notes (`is_return=1`) generated invalid PEPPOL XML using Invoice document structure instead of CreditNote.

### Solution
- Use `<CreditNote>` root element for credit notes, `<Invoice>` for regular invoices
- Use `<CreditNoteTypeCode>` and skip `<DueDate>` in credit notes
- Use `<CreditNoteLine>` and `<CreditedQuantity>` for credit note line items
- Select correct XSD schema (`UBL-CreditNote-2.1` vs `UBL-Invoice-2.1`) for validation

### Changes
- `peppol/generator.py`: Dynamic element names based on `is_return` flag
- `utils.py`: XSD schema selection based on document type
- `sales_invoice.py`: Pass invoice to schema selector

### Testing
- ✅ Credit notes pass XSD validation
- ✅ BR-CL-01 validation passes